### PR TITLE
fix: avoid wasted calls

### DIFF
--- a/lib/innertube.rb
+++ b/lib/innertube.rb
@@ -123,9 +123,8 @@ module Innertube
 
       result = nil
       element = nil
-      opts[:filter] ||= proc {|_| true }
       @lock.synchronize do
-        element = @pool.find { |e| e.unlocked? && opts[:filter].call(e.object) }
+        element = @pool.find { |e| e.unlocked? && (opts[:filter].nil? || opts[:filter].call(e.object)) }
         unless element
           # No objects were acceptable
           resource = opts[:default] || @open.call


### PR DESCRIPTION
```
development> l = proc { true }
development> Benchmark.ips do |x|
development*   x.report('callable') { if l.call; [] << 1; end }
development*   x.report('without callable') { if true; [] << 1; end }
development*   x.compare!
development* end
Warming up --------------------------------------
            callable   521.998k i/100ms
    without callable   733.721k i/100ms
Calculating -------------------------------------
            callable      5.412M (±16.4%) i/s -     26.622M in   5.055133s
    without callable      7.806M (±16.5%) i/s -     38.153M in   5.006901s

Comparison:
    without callable:  7805816.6 i/s
            callable:  5412398.5 i/s - 1.44x  (± 0.00) slower
```